### PR TITLE
Quick fix for unresolved dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The following dependencies should be added to your build (see the double %% that
 maven-built artifacts from SBT-built artifacts).
 
     resolvers += Resolver.sonatypeRepo("snapshots")
+
+    libraryDependencies += "org.scalamacros" % "resetallattrs_2.11" % "1.0.0"
     
     libraryDependencies += "com.github.baccata" %% "yausl" % "0.1.0-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val yausl = project.in(file("."))
   .settings(
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.2.0-RC4",
-      "org.specs2" %% "specs2-core" % "3.6" % "test"
+      "org.specs2" %% "specs2-core" % "3.8" % "test"
     ))
   .settings(headers := Map("scala" -> Apache2_0("2015", "Olivier Mélois")))
 
@@ -51,7 +51,7 @@ lazy val macroProjectSettings = Seq(
   ),
   libraryDependencies ++= (
     if (scalaVersion.value.startsWith("2.10")) List(paradiseDependency)
-    else List("org.scalamacros" %% "resetallattrs" % "1.0.0-SNAPSHOT")
+    else List("org.scalamacros" %% "resetallattrs" % "1.0.0")
     )
 )
 


### PR DESCRIPTION
I was having issues about unresolved dependencies in two cases:

**First case:** If I follow the 'usage' section of Readme, and put this in my `build.sbt`:

``` scala
resolvers += Resolver.sonatypeRepo("snapshots")

libraryDependencies += "com.github.baccata" %% "yausl" % "0.1.0-SNAPSHOT"
```

it gives the output:

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scalamacros#resetallattrs_2.11;1.0.0-SNAPSHOT: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]      org.scalamacros:resetallattrs_2.11:1.0.0-SNAPSHOT
[warn]        +- com.github.baccata:yausl_2.11:0.1.0-SNAPSHOT (/full/path/yausl/build.sbt#L12-13)
[warn]        +- hello:hello_2.11:0.2
[trace] Stack trace suppressed: run last *:update for the full output.
[error] (*:update) sbt.ResolveException: unresolved dependency: org.scalamacros#resetallattrs_2.11;1.0.0-SNAPSHOT: not found
```

I solved the problem by adding this line right above Yausl dependency line in build.sbt:

``` scala
libraryDependencies += "org.scalamacros" % "resetallattrs_2.11" % "1.0.0"
```

This goes for resetallattrs 1.0.0, (as opposed to 1.0.0-SNAPSHOT, which was not found in sonatype or maven), and gives the warning:

```
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * org.scalamacros:resetallattrs_2.11:1.0.0-SNAPSHOT -> 1.0.0
[warn] Run 'evicted' to see detailed eviction warnings
```

but works fine otherwise.

**Second case:** If I clone the code, I get a similar error:

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scalamacros#resetallattrs_2.11;1.0.0-SNAPSHOT: not found
[warn]  :: org.scalaz.stream#scalaz-stream_2.11;0.7a: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]      org.scalamacros:resetallattrs_2.11:1.0.0-SNAPSHOT (/full/path/yausl/build.sbt#L52)
[warn]        +- com.github.baccata:yausl_2.11:0.1.0-SNAPSHOT
[warn]      org.scalaz.stream:scalaz-stream_2.11:0.7a
[warn]        +- org.specs2:specs2-common_2.11:3.6
[warn]        +- org.specs2:specs2-matcher_2.11:3.6
[warn]        +- org.specs2:specs2-core_2.11:3.6 (/full/path/yausl/build.sbt#L9)
[warn]        +- com.github.baccata:yausl_2.11:0.1.0-SNAPSHOT
[trace] Stack trace suppressed: run last *:update for the full output.
[error] (*:update) sbt.ResolveException: unresolved dependency: org.scalamacros#resetallattrs_2.11;1.0.0-SNAPSHOT: not found
[error] unresolved dependency: org.scalaz.stream#scalaz-stream_2.11;0.7a: not found
```

And to fix this, I made updates to build.sbt. I changed specs2-core dependency from 3.6 to 3.8. I also changed resetallattrs dependency to version "1.0.0" without snapshot, and it worked fine, all tests passing.

Now I'm sure this is just a hotfix as opposed to true solution, but I still wanted to share.

I'm using Scala 2.11.6, and 0.13.11
I replaced full paths with "/full/path/" in sbt warnings.
